### PR TITLE
Migrate to CentOS 7 and glibc 2.17

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,9 @@
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +8,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-64
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,3 @@
-c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,6 +8,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_stdlib_version
-  - cdt_name

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,3 +10,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+os_version:
+  linux_64: cos7
+  linux_aarch64: cos7
+  linux_ppc64le: cos7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 2e402c471dedcc41bb0be2517a836bdadcc539ce799fb7599304c5ffdc7dc566  # [ppc64le]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [aarch64 or osx or win]
 
 requirements:


### PR DESCRIPTION
According to https://github.com/conda-forge/conda-forge.github.io/issues/2102, the Conda-forge ecosystem is migrating to CentOS 7 and glibc 2.17 this summer.
This pull request proactively migrates this package.